### PR TITLE
fixed I18n resource file lookup

### DIFF
--- a/src/smeagol/util.clj
+++ b/src/smeagol/util.clj
@@ -58,7 +58,7 @@
   (merge
     (i18n/get-messages
       ((:headers request) "accept-language")
-      (.getAbsolutePath (cjio/file  (io/resource-path) ".." "i18n"))
+      (str (clojure.java.io/resource "i18n/"))     
       "en-GB")
     config))
 


### PR DESCRIPTION
Fixed the lookup of I18N resources. 

Reading https://stackoverflow.com/questions/8009829/resources-in-clojure-applications made me think about how clojure would resolve paths at runtime with the classpath and it seems using (str (clojure.java.io/resource "<path>") is the recommended way to do this. I've tested this on my own machine and can see the .gb strings picked up successfully. 

