### PR TITLE
fixed path for resolving passwd file when deployed via JAR

### DIFF
--- a/src/smeagol/authenticate.clj
+++ b/src/smeagol/authenticate.clj
@@ -34,7 +34,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; the relative path to the password file.
-(def password-file-path (str (io/resource-path) "../passwd"))
+(def password-file-path (str (clojure.java.io/resource "passwd")))
 
 
 (defn- get-users


### PR DESCRIPTION
When deploying as a JAR file, the passwd file is not picked up using the standard io operation. To deal with this, I changed to used clojure.java.io/resource "passwd". Doing this, I've been able to successfully display the smeagol landing page, login as admin/admin and be able to click the "edit" link.

The only oddity I've noticed with deployment is having to press "enter" on the command line to move forward (almost like a readline/breakpoint is in place). 

We should look to doing a wholesale update for any places where filepaths are used to ensure the classpath is consulted rather than specifying absolute file paths