### PR TITLE
fix rings & noirs resource upload & serve location

### DIFF
--- a/src/smeagol/handler.clj
+++ b/src/smeagol/handler.clj
@@ -97,6 +97,7 @@
   [xss-protection?]
   (-> site-defaults
       (update-in [:session] merge session-defaults)
+      (dissoc :static)
       (assoc-in [:security :anti-forgery] xss-protection?)))
 
 

--- a/src/smeagol/middleware.clj
+++ b/src/smeagol/middleware.clj
@@ -50,9 +50,9 @@
 
 (def production-middleware
   [#(wrap-internal-error % :log (fn [e] (timbre/error e)))
+   #(wrap-resource % "public")
    #(wrap-file % util/content-dir
                {:index-files? false :prefer-handler? true})
-   #(wrap-resource % "public")
    #(wrap-content-type %)
    #(wrap-not-modified %)])
 

--- a/src/smeagol/middleware.clj
+++ b/src/smeagol/middleware.clj
@@ -6,7 +6,12 @@
             [selmer.middleware :refer [wrap-error-page]]
             [prone.middleware :refer [wrap-exceptions]]
             [ring.middleware.anti-forgery :refer [wrap-anti-forgery]]
-            [noir-exception.core :refer [wrap-internal-error]]))
+            [ring.middleware.file :refer [wrap-file]]
+            [ring.middleware.resource :refer [wrap-resource]]
+            [ring.middleware.content-type :refer [wrap-content-type]]
+            [ring.middleware.not-modified :refer [wrap-not-modified]]
+            [noir-exception.core :refer [wrap-internal-error]]
+            [smeagol.util :as util]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;
@@ -44,7 +49,12 @@
 
 
 (def production-middleware
-  [#(wrap-internal-error % :log (fn [e] (timbre/error e)))])
+  [#(wrap-internal-error % :log (fn [e] (timbre/error e)))
+   #(wrap-file % util/content-dir
+               {:index-files? false :prefer-handler? true})
+   #(wrap-resource % "public")
+   #(wrap-content-type %)
+   #(wrap-not-modified %)])
 
 
 (defn load-middleware []

--- a/src/smeagol/routes/wiki.clj
+++ b/src/smeagol/routes/wiki.clj
@@ -52,6 +52,7 @@
   "Process `source-text` and save it to the specified `file-path`, committing it
   to Git and finally redirecting to wiki-page."
   [params suffix request]
+  (timbre/trace (format "process-source: '%s'" request))
   (let [source-text (:src params)
         page (:page params)
         file-name (str page suffix)
@@ -122,6 +123,7 @@
 (defn wiki-page
   "Render the markdown page specified in this `request`, if any. If none found, redirect to edit-page"
   [request]
+  (timbre/trace (format "wiki-page: '%s'" request))
   (or
     (show-sanity-check-error)
     (let [params (keywordize-keys (:params request))
@@ -163,7 +165,7 @@
   "Render a form to allow the upload of a file."
   [request]
   (let [params (keywordize-keys (:params request))
-        data-path (str (io/resource-path) "/content/uploads/")
+        data-path (str util/content-dir "/content/uploads/")
         git-repo (hist/load-or-init-repo util/content-dir)
         upload (:upload params)
         uploaded (if upload (ul/store-upload params data-path))

--- a/src/smeagol/uploads.clj
+++ b/src/smeagol/uploads.clj
@@ -56,9 +56,11 @@
         filename (:filename upload)]
     (timbre/info
       (str "Storing upload file: " upload))
-      (if tmp-file
-        (do
-          (.renameTo tmp-file
-                     (File. (str path filename)))
-          filename)
-        (throw (Exception. "No file found?")))))
+    (timbre/debug
+      (str "store-upload mv file: " tmp-file " to: " path filename))
+    (if tmp-file
+      (do
+        (.renameTo tmp-file
+                   (File. (str path filename)))
+        filename)
+      (throw (Exception. "No file found?")))))


### PR DESCRIPTION
I found some issues around uploading & serving resources ...
I use a dedicated uberjar & separated content git repo on different path. Unfortunately smeagol seems to upload & slurp resources from classpath only - so upload & serving resources does not work.

I found some places to fix it - now it works on my scenario & tests are green.
But as I do not know lib-noir there maybe some sideeffects on the ring-hanlder vector ...

What do you think about?