### PR TITLE
make start page configurable

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,6 +28,7 @@
 ;;      ;       ;       ;       ;       ;       ;       ;       ;       ;
 {
   :content-dir          "resources/public/content"
+  :start-page           "README"
                                         ;; where content is served from.
   :default-locale       "en-GB"         ;; default language used for messages
   :formatters           {"vega"         smeagol.formatting/process-vega
@@ -38,6 +39,5 @@
                                         ;; :trace :debug :info :warn :error :fatal
   :passwd               "resources/passwd"
                                         ;; where the password file is stored
-  :site-title           "Smeagol"       ;; overall title of the site, used in
+  :site-title           "Smeagol"}       ;; overall title of the site, used in
                                         ;; page headings
-}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,7 +28,7 @@
 ;;      ;       ;       ;       ;       ;       ;       ;       ;       ;
 {
   :content-dir          "resources/public/content"
-  :start-page           "README"
+  :start-page           "Introduction"
                                         ;; where content is served from.
   :default-locale       "en-GB"         ;; default language used for messages
   :formatters           {"vega"         smeagol.formatting/process-vega

--- a/src/smeagol/routes/wiki.clj
+++ b/src/smeagol/routes/wiki.clj
@@ -125,7 +125,7 @@
   (or
     (show-sanity-check-error)
     (let [params (keywordize-keys (:params request))
-          page (or (:page params) (util/get-message :default-page-title "Introduction" request))
+          page (or (:page params) util/start-page (util/get-message :default-page-title "Introduction" request))
           file-name (str page ".md")
           file-path (cjio/file util/content-dir file-name)
           exists? (.exists (clojure.java.io/as-file file-path))]

--- a/src/smeagol/util.clj
+++ b/src/smeagol/util.clj
@@ -35,6 +35,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
+(def start-page
+  (:start-page  config))
+
 (def content-dir
   (or
     (:content-dir config)


### PR DESCRIPTION
As we're using a separate wiki (https://github.com/DomainDrivenArchitecture/dda), it would be cool, to have the same intro-page on github & in wiki.

Added the option to define the README.md as start-page.